### PR TITLE
feat: ignore leave of individual devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 This repository contains user extensions to be used with Zigbee2MQTT. For more information see the [Zigbee2MQTT docs](https://www.zigbee2mqtt.io/advanced/more/external_extensions.html).
 
 ## Stable
-The extensions listed here are considered **stable** and are not expected to  get breaking changes or a lot of active development.
+The extensions listed here are considered **stable** and are not expected to get breaking changes or a lot of active development.
 
-- [color_mode_reader](stable/color_mode_reader/README.md): simple extension to read the read `lightingColorCtrl.colorMode` when reporting is not supported.
+- [color_mode_reader](stable/color_mode_reader/README.md): reads `lightingColorCtrl.colorMode` for devices (e.g. Philips Hue BT) that do not support reporting it.
+- [ignore_device_leave](stable/ignore_device_leave/README.md): prevents Z2M from removing specific devices from its database when they send spurious leave events caused by accidental factory resets (common with Tuya TS0505B bulbs behind wall switches or relays).
+- [permit_join_forever](stable/permit_join_forever/README.md): keeps permit-join open indefinitely. Required for some devices (e.g. Livolo) that need extended pairing windows. **Use only when necessary.**
 
 ## Unstable
-The extensions listed here are considered **unstable** and are under active development, breaking changes and frequent updates are expected.
+The extensions listed here are considered **unstable** and are under active development; breaking changes and frequent updates are expected.
 
-- [miboxer-fut089z/controls-exposer](unstable/miboxer-fut089z/controls-exposer.js): this extension exposes the controls of all MiBoxer FUT089Z remotes
+- [DewpointCalculator](unstable/DewpointCalculator/README.md): calculates and injects dewpoint into every device message that contains both temperature and humidity.
+- [miboxer-fut089z/controls-exposer](unstable/miboxer-fut089z/README.md): exposes the controls of MiBoxer FUT089Z remotes, which only emit group commands not supported by zigbee-herdsman-converters.
+- [mcp-server](unstable/mcp-server/README.md): a Model Context Protocol server that lets AI tools (Claude, Cursor, etc.) interact with your Zigbee network programmatically.

--- a/stable/ignore_device_leave/README.md
+++ b/stable/ignore_device_leave/README.md
@@ -1,0 +1,76 @@
+# ignore_device_leave
+
+Prevents Zigbee2MQTT from removing specific devices from its database when they send `deviceLeave` events caused by accidental factory resets.
+
+## Background
+
+Tuya Zigbee devices (e.g. TS0505B-based ceiling spots like Moes ZB-TDD6-RCW-4 and ZB-TD5-RCW-GU10) enter pairing mode after only 3 power cycles. Other brands typically require 5 or more. This low threshold makes accidental resets easy to trigger in real-world installations:
+
+- **Bouncy relay contacts** — a relay switching under load can produce multiple contact bounces that the device counts as separate power cycles
+- **Noisy mains lines** — voltage dips or transients during power-on
+- **Wall switches** — rapid toggling, or a child playing with a switch
+
+When the device enters pairing mode it does what it is supposed to do: sends a `Leave_Indication` and waits for a new coordinator to pair with. From the device's perspective this is correct behaviour. The problem is that after the pairing timeout expires the device gives up and resumes normal operation — still on the network, still holding its network key — but zigbee-herdsman has already processed the leave event and removed the device from its database. All subsequent messages from the device are silently dropped.
+
+The device is physically present and immediately controllable again once the database entry is restored (manually or by re-pairing), without any reconfiguration of attributes, groups, or bindings.
+
+See upstream discussion: [zigbee-herdsman #1648](https://github.com/Koenkk/zigbee-herdsman/issues/1648)
+
+## What this extension does
+
+It intercepts the adapter-level `deviceLeave` event before herdsman processes it. For any device whose model ID or IEEE address is in the ignore list, the leave event is suppressed and a warning is logged. All other devices continue through the normal leave handler unchanged.
+
+The original listeners are saved on `start()` and fully restored on `stop()`, so the extension is reversible without a Z2M restart.
+
+## Configuration
+
+Edit the two arrays at the top of `ignore_device_leave.js`:
+
+```js
+const IGNORE_MODELS = ['TS0505B'];   // match by modelID — affects all units of that model
+const IGNORE_DEVICES = [];            // match by IEEE address — targets specific units
+```
+
+Use model-based matching when most or all units of a model exhibit accidental resets:
+
+```js
+const IGNORE_MODELS = ['TS0505B'];
+```
+
+Use address-based matching when only specific individual units are problematic:
+
+```js
+const IGNORE_MODELS = [];
+const IGNORE_DEVICES = ['0xa4c138xxxxxxxx', '0xa4c138yyyyyyyy'];
+```
+
+Both lists can be combined. A device matching either is ignored.
+
+## Installation
+
+1. In the Z2M web UI go to **Settings → Dev Console → External Extensions**.
+2. Create a new extension. The filename **must** end in `.mjs`, e.g. `ignore_leave.mjs`.
+3. Paste the contents of `ignore_device_leave.js` into the Code form.
+4. Save. The extension loads immediately — no Z2M restart needed.
+
+On load you will see:
+
+```
+patching deviceLeave handler to ignore models=["TS0505B"] devices=[]
+```
+
+When a leave event is suppressed:
+
+```
+Ignoring leave from 0xa4c138xxxxxxxx (TS0505B)
+```
+
+## Trade-offs and risks
+
+This extension is an opt-in workaround, not a fix. Understand the implications before using it.
+
+**If a device is intentionally decommissioned** (factory reset for re-pairing to a different coordinator), the leave event will be suppressed. The device will appear in Z2M but be unreachable. Remove it manually from the Z2M device list in that case.
+
+**This does not prevent the accidental reset** — the device still enters pairing mode, blinks, and waits for a coordinator. It just prevents Z2M from losing its database entry while that happens. After the pairing timeout the device resumes normal operation automatically.
+
+**Monkey-patching fragility** — the extension hooks into zigbee-herdsman's internal adapter event emitter. A Z2M or herdsman update that changes this internal interface could break it silently. Verify after upgrades.

--- a/stable/ignore_device_leave/ignore_device_leave.js
+++ b/stable/ignore_device_leave/ignore_device_leave.js
@@ -1,0 +1,32 @@
+const IGNORE_MODELS  = ['TS0505B'];
+const IGNORE_DEVICES = [];
+
+export default class IgnoreLeave {
+  constructor(zigbee, _1, _2, _3, _4, _5, _6, _7, _8, logger) {
+    const ctrl      = zigbee.zhController;
+    this._adapter   = ctrl.adapter;
+    this._getDevice = ctrl.getDeviceByIeeeAddr.bind(ctrl);
+    this._logger    = logger;
+    this._orig      = [];
+  }
+
+  async start() {
+    this._orig = this._adapter.rawListeners('deviceLeave').slice();
+    this._adapter.removeAllListeners('deviceLeave');
+    this._adapter.on('deviceLeave', (p) => {
+      const d = this._getDevice(p.ieeeAddr);
+      if (d && (IGNORE_MODELS.includes(d.modelID) || IGNORE_DEVICES.includes(d.ieeeAddr))) {
+        this._logger.warning(`Ignoring leave from ${d.ieeeAddr} (${d.modelID})`);
+        return;
+      }
+      this._orig.forEach(fn => fn(p));
+    });
+    this._logger.warning(`patching deviceLeave handler to ignore models=${IGNORE_MODELS} devices=${IGNORE_DEVICES}`);
+  }
+
+  async stop() {
+    this._adapter.removeAllListeners('deviceLeave');
+    this._orig.forEach(fn => this._adapter.on('deviceLeave', fn));
+    this._orig = [];
+  }
+}


### PR DESCRIPTION
Adds the `ignore_device_leave` extension


Tuya TS0505B-based bulbs (Moes ZB-TDD6-RCW-4, ZB-TD5-RCW-GU10) enter pairing mode after only 3 power cycles — a threshold easily crossed by bouncy relay contacts, noisy mains lines, or rapid switch toggling. 

When the device does so, herdsman removes it from `shepherd.db`, causing all subsequent messages to be silently dropped. The device is still physically on the network and immediately controllable once the database entry is restored. This extension prevents the entry from being lost in the first place.
  
Upstream feature request was closed as not planned: [zigbee-herdsman #1648](https://github.com/Koenkk/zigbee-herdsman/issues/1648).


## Example Usage

Edit the two arrays at the top of the file before installing:

```js
const IGNORE_MODELS  = ['TS0505B'];           // by modelID — all units of this model
const IGNORE_DEVICES = ['0xa4c138xxxxxxxx'];  // by IEEE address — specific units only
```

Install via Settings → Dev Console → External Extensions in the Z2M web UI. The filename must end in .mjs (e.g. ignore_leave.mjs). No restart required.

AI Disclaimer:

- Claude Code was used to generate documentation. I have manually refined it as not all assumptions were correct.
- Extension Implementation was AI assisted but mostly "hand crafted"
- Summaries of missing extensions were generated in the top level README.md and I did  briefly check them. I did not read the source code of those to ensure 100% correctness.  
