### PR TITLE
feat: add desired state retry extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ The extensions listed here are considered **stable** and are not expected to get
 The extensions listed here are considered **unstable** and are under active development; breaking changes and frequent updates are expected.
 
 - [DewpointCalculator](unstable/DewpointCalculator/README.md): calculates and injects dewpoint into every device message that contains both temperature and humidity.
+- [desired_state_retry](unstable/desired_state_retry/README.md): retries verifiable device `/set` commands until the requested state is observed or the retry budget is exhausted.
 - [miboxer-fut089z/controls-exposer](unstable/miboxer-fut089z/README.md): exposes the controls of MiBoxer FUT089Z remotes, which only emit group commands not supported by zigbee-herdsman-converters.
 - [mcp-server](unstable/mcp-server/README.md): a Model Context Protocol server that lets AI tools (Claude, Cursor, etc.) interact with your Zigbee network programmatically.

--- a/unstable/desired_state_retry/README.md
+++ b/unstable/desired_state_retry/README.md
@@ -1,0 +1,62 @@
+# Desired state retry
+
+Retries verifiable device `/set` commands when Zigbee2MQTT does not observe the requested state after the normal publish.
+
+This extension is intended for lossy actuator networks where the first command may be dropped, for example covers or switches that usually work one by one but sometimes miss a command during a burst.
+
+## What this extension does
+
+- watches incoming device MQTT `/set` commands
+- records simple, verifiable target state values such as `state: "OPEN"` or `state: "OFF"`
+- retries the same MQTT command after a cooldown until the target state is observed, superseded, exhausted, or expired
+- coalesces duplicate unresolved commands for the same device endpoint
+- supersedes an older pending target when a newer target is sent to the same device endpoint
+
+The first command is still handled by Zigbee2MQTT normally. This extension only adds retries after the requested state has not been observed.
+
+## What this extension does not do
+
+- it does not handle groups
+- it does not retry bridge request topics
+- it does not infer complex converter-specific target states
+- it does not retry commands such as `toggle` or `stop`, where repeating the command can change behavior or has no stable target state
+- it does not reorder the initial command burst before Zigbee2MQTT sends it
+
+## Configuration
+
+Edit the `CONFIG` object at the top of `desired_state_retry.js`:
+
+```js
+const CONFIG = {
+    devices: [],
+    properties: ['state'],
+    maxRetries: 4,
+    retryCooldownSeconds: 4,
+    deadlineSeconds: 30,
+};
+```
+
+Set `devices` to specific friendly names or IEEE addresses:
+
+```js
+devices: ['Living room cover', '0xa4c1380011223344'],
+```
+
+Leaving `devices` empty disables retries. Use `['*']` only when every device command with a supported property should be retried.
+
+## Installation
+
+1. In the Zigbee2MQTT web UI go to **Settings -> Dev Console -> External Extensions**.
+2. Create a new extension named `desired_state_retry.js`.
+3. Paste the contents of `desired_state_retry.js` into the code form.
+4. Save. The extension loads immediately.
+
+## Trade-offs and risks
+
+This is an opt-in workaround, not a Zigbee delivery guarantee.
+
+Commands are retried by publishing the same MQTT `/set` command again. That works well for idempotent actuator targets such as `OPEN`, `CLOSE`, `ON`, and `OFF`, but it is not suitable for semantic actions where repeating the command changes the meaning.
+
+The extension uses Zigbee2MQTT's external extension API and normal MQTT command path. It intentionally avoids monkey-patching the built-in publish extension, so it cannot delay or reorder the first command in a burst.
+
+The retry budget is counted after the original Zigbee2MQTT command. For example, `maxRetries: 4` means one normal command plus up to four retry publishes.

--- a/unstable/desired_state_retry/desired_state_retry.js
+++ b/unstable/desired_state_retry/desired_state_retry.js
@@ -1,0 +1,368 @@
+const CONFIG = {
+    // List friendly names or IEEE addresses. Use ['*'] only when every device
+    // with a supported property should be retried.
+    devices: [],
+    // Retried properties. `state` covers on/off/open/close style actuators.
+    properties: ['state'],
+    maxRetries: 4,
+    retryCooldownSeconds: 4,
+    deadlineSeconds: 30,
+};
+
+const STATE_VALUES = ['on', 'off', 'open', 'close', 'lock', 'unlock'];
+
+class DesiredStateRetry {
+    constructor(zigbee, mqtt, state, _publishEntityState, eventBus, _enableDisableExtension, _restartCallback, _addExtension, settings, logger) {
+        this.zigbee = zigbee;
+        this.mqtt = mqtt;
+        this.state = state;
+        this.eventBus = eventBus;
+        this.settings = settings;
+        this.logger = logger;
+        this.targets = new Map();
+        this.ownPublishes = new Map();
+        this.running = false;
+        this.runScheduled = false;
+    }
+
+    start() {
+        if (!CONFIG.devices.length) {
+            this.logger.warning('desired_state_retry has no configured devices; extension is loaded but will not retry commands');
+        }
+
+        this.eventBus.onMQTTMessage(this, this.onMQTTMessage.bind(this));
+        this.eventBus.onStateChange(this, this.onStateChange.bind(this));
+        this.logger.warning('desired_state_retry loaded; this is an opt-in workaround for lossy device commands');
+    }
+
+    stop() {
+        for (const target of this.targets.values()) {
+            this.clearTimer(target);
+        }
+
+        this.targets.clear();
+        this.ownPublishes.clear();
+        this.eventBus.removeListeners(this);
+    }
+
+    onMQTTMessage(data) {
+        const parsed = this.parseMQTTMessage(data);
+
+        if (!parsed) {
+            return;
+        }
+
+        if (this.consumeOwnPublish(data.topic, data.message)) {
+            return;
+        }
+
+        const target = this.buildTarget(parsed, data);
+
+        if (!target) {
+            return;
+        }
+
+        const key = this.key(target);
+        const existing = this.targets.get(key);
+
+        if (existing) {
+            if (sameState(existing.targetState, target.targetState)) {
+                existing.topic = target.topic;
+                existing.message = target.message;
+                this.logger.debug(`Coalesced desired state retry for '${key}'`);
+                return;
+            }
+
+            this.supersede(key, existing);
+        }
+
+        this.targets.set(key, target);
+        this.armTimer(target);
+        this.scheduleRun();
+    }
+
+    parseMQTTMessage(data) {
+        const baseTopic = this.settings.get().mqtt.base_topic;
+        const prefix = `${baseTopic}/`;
+
+        if (!data.topic.startsWith(prefix)) {
+            return undefined;
+        }
+
+        const relativeTopic = data.topic.slice(prefix.length);
+
+        if (relativeTopic.startsWith('bridge/')) {
+            return undefined;
+        }
+
+        const parts = relativeTopic.split('/');
+        const setIndex = parts.indexOf('set');
+
+        if (setIndex < 1) {
+            return undefined;
+        }
+
+        const deviceAndEndpoint = parts.slice(0, setIndex).join('/');
+        const topicProperty = parts[setIndex + 1];
+
+        return {deviceAndEndpoint, topicProperty};
+    }
+
+    buildTarget(parsed, data) {
+        const resolved = this.zigbee.resolveEntityAndEndpoint(parsed.deviceAndEndpoint);
+        const entity = this.zigbee.resolveEntity(resolved.ID);
+
+        if (!entity || !entity.isDevice()) {
+            return undefined;
+        }
+
+        if (!this.matchesConfiguredDevice(entity)) {
+            return undefined;
+        }
+
+        const message = parsePayload(data.message, parsed.topicProperty);
+
+        if (!message) {
+            return undefined;
+        }
+
+        const endpointID = resolved.endpointID || 'default';
+        const endpointNames = entity.getEndpointNames ? entity.getEndpointNames() : [];
+        const propertyEndpointRegex = endpointNames.length ? new RegExp(`^(.*?)_(${endpointNames.map(escapeRegex).join('|')})$`) : undefined;
+        const targetState = {};
+
+        for (const [rawKey, value] of Object.entries(message)) {
+            let property = rawKey;
+            let stateKey = rawKey;
+
+            if (propertyEndpointRegex) {
+                const match = rawKey.match(propertyEndpointRegex);
+
+                if (match) {
+                    property = match[1];
+                    stateKey = rawKey;
+                }
+            }
+
+            if (!CONFIG.properties.includes(property)) {
+                continue;
+            }
+
+            if (!isVerifiableValue(value)) {
+                continue;
+            }
+
+            if (resolved.endpointID && !stateKey.endsWith(`_${resolved.endpointID}`)) {
+                stateKey = `${stateKey}_${resolved.endpointID}`;
+            }
+
+            targetState[stateKey] = normalizeComparableValue(value);
+        }
+
+        if (!Object.keys(targetState).length) {
+            return undefined;
+        }
+
+        const now = Date.now();
+
+        return {
+            entity,
+            endpointID,
+            targetState,
+            topic: data.topic,
+            message: data.message,
+            retries: 0,
+            createdAt: now,
+            deadlineAt: now + CONFIG.deadlineSeconds * 1000,
+            nextEligibleAt: now + CONFIG.retryCooldownSeconds * 1000,
+            inFlight: false,
+            timer: undefined,
+        };
+    }
+
+    matchesConfiguredDevice(entity) {
+        return CONFIG.devices.includes('*') || CONFIG.devices.includes(entity.name) || CONFIG.devices.includes(entity.ieeeAddr);
+    }
+
+    onStateChange(data) {
+        if (!data.entity?.isDevice?.()) {
+            return;
+        }
+
+        for (const [key, target] of this.targets) {
+            if (target.entity.ieeeAddr === data.entity.ieeeAddr && isApplied(target.targetState, data.to)) {
+                this.complete(key, target, 'applied');
+            }
+        }
+    }
+
+    scheduleRun() {
+        if (this.runScheduled) {
+            return;
+        }
+
+        this.runScheduled = true;
+        queueMicrotask(() => {
+            this.runScheduled = false;
+            void this.run();
+        });
+    }
+
+    async run() {
+        if (this.running) {
+            return;
+        }
+
+        this.running = true;
+
+        try {
+            while (true) {
+                const target = this.nextEligible();
+
+                if (!target) {
+                    break;
+                }
+
+                await this.retry(target);
+            }
+        } finally {
+            this.running = false;
+        }
+    }
+
+    nextEligible() {
+        const now = Date.now();
+        const candidates = Array.from(this.targets.values()).filter((target) => !target.inFlight && target.nextEligibleAt <= now);
+
+        candidates.sort((a, b) => a.createdAt - b.createdAt);
+
+        return candidates[0];
+    }
+
+    async retry(target) {
+        const key = this.key(target);
+
+        if (Date.now() >= target.deadlineAt || target.retries >= CONFIG.maxRetries) {
+            this.complete(key, target, 'failed');
+            return;
+        }
+
+        target.inFlight = true;
+        target.retries += 1;
+        this.rememberOwnPublish(target.topic, target.message);
+
+        try {
+            this.logger.debug(`Retrying desired state '${key}' retry ${target.retries}/${CONFIG.maxRetries}`);
+            await this.mqtt.publish(target.topic.slice(`${this.settings.get().mqtt.base_topic}/`.length), target.message, {skipReceive: false});
+        } finally {
+            target.inFlight = false;
+        }
+
+        if (this.targets.get(key) !== target) {
+            return;
+        }
+
+        target.nextEligibleAt = Date.now() + CONFIG.retryCooldownSeconds * 1000;
+        this.armTimer(target);
+    }
+
+    rememberOwnPublish(topic, message) {
+        const key = `${topic}\n${message}`;
+        this.ownPublishes.set(key, (this.ownPublishes.get(key) || 0) + 1);
+    }
+
+    consumeOwnPublish(topic, message) {
+        const key = `${topic}\n${message}`;
+        const count = this.ownPublishes.get(key) || 0;
+
+        if (!count) {
+            return false;
+        }
+
+        if (count === 1) {
+            this.ownPublishes.delete(key);
+        } else {
+            this.ownPublishes.set(key, count - 1);
+        }
+
+        return true;
+    }
+
+    key(target) {
+        return `${target.entity.ieeeAddr}/${target.endpointID}`;
+    }
+
+    supersede(key, target) {
+        this.clearTimer(target);
+        this.targets.delete(key);
+        this.logger.debug(`Superseded desired state retry for '${key}'`);
+    }
+
+    complete(key, target, status) {
+        this.clearTimer(target);
+        this.targets.delete(key);
+        this.logger.debug(`Desired state retry for '${key}' ${status} after ${target.retries} retr${target.retries === 1 ? 'y' : 'ies'}`);
+    }
+
+    armTimer(target) {
+        this.clearTimer(target);
+        target.timer = setTimeout(() => void this.run(), Math.max(0, target.nextEligibleAt - Date.now()));
+    }
+
+    clearTimer(target) {
+        if (target.timer) {
+            clearTimeout(target.timer);
+            target.timer = undefined;
+        }
+    }
+}
+
+function parsePayload(payload, topicProperty) {
+    if (topicProperty) {
+        return {[topicProperty]: parseValue(payload)};
+    }
+
+    const parsed = parseValue(payload);
+
+    if (typeof parsed === 'string' && STATE_VALUES.includes(parsed.toLowerCase())) {
+        return {state: parsed};
+    }
+
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : undefined;
+}
+
+function parseValue(value) {
+    try {
+        return JSON.parse(value);
+    } catch {
+        return value;
+    }
+}
+
+function isVerifiableValue(value) {
+    return ['string', 'number', 'boolean'].includes(typeof value);
+}
+
+function normalizeComparableValue(value) {
+    return typeof value === 'string' ? value.toUpperCase() : value;
+}
+
+function isApplied(targetState, currentState) {
+    for (const [key, value] of Object.entries(targetState)) {
+        if (normalizeComparableValue(currentState[key]) !== value) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function sameState(left, right) {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function escapeRegex(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = DesiredStateRetry;


### PR DESCRIPTION
## Summary

- add an unstable `desired_state_retry` external extension for lossy actuator commands
- retry simple, verifiable device `/set` targets until Zigbee2MQTT observes the requested state or the retry budget expires
- keep retries disabled until devices are explicitly listed, with `['*']` available only for deliberate all-device use
- document the scope and limits, including no group support and no initial burst reordering

## Context

This is a narrower user-extension version of the desired-state retry idea from Koenkk/zigbee2mqtt#32253, after the maintainer suggestion that the feature is a better fit for this repository.

The extension intentionally stays on the normal external-extension and MQTT command path instead of monkey-patching Zigbee2MQTT's built-in publish extension. That means the first command is still sent normally by Zigbee2MQTT, and this extension only retries later when the requested state was not observed.

## Validation

- `node --check unstable/desired_state_retry/desired_state_retry.js`
- `git diff --check`
- local in-memory smoke: empty `devices` does not track targets, `['*']` retries a missed `CLOSE` command once with `skipReceive: false`, the extension ignores its own returned MQTT message, and a later state confirmation completes the target
